### PR TITLE
Fix typo in German tip translation

### DIFF
--- a/Tips/Tips.json
+++ b/Tips/Tips.json
@@ -105,7 +105,7 @@
     "Du kannst deine Framerate (und deinen Batterieverbrauch) verbessern, indem du in den Grafikeinstellungen Anti-Aliasing deaktivierst und die Renderingauflösung reduzierst.",
     "Replay-Tipp: Halte den Bildschirm an einer beliebingen Stelle gedrückt, um die Benutzeroberfläche auszublenden. Um die Oberfläche wieder einzublenden, halte den Bildschirm erneut gedrückt.",
     "Tipp für den Autopiloten: Aktiviere VNAV 1 Minute bevor du deinen Sinkflug beginnen musst.",
-    "Tipp: Um Treinbstoff zu sparen kannst du mit nur einem Triebwerk rollen und das zweite Triebwerk erst kurz vor dem Start anlassen.",
+    "Tipp: Um Treibstoff zu sparen kannst du mit nur einem Triebwerk rollen und das zweite Triebwerk erst kurz vor dem Start anlassen.",
     "Besuche unser Benutzerhandbuch auf der Startseite um tiefergehende Anleitungen zu finden.",
     "Tipp: Achte im Sinkflug auf deine Geschwindigkeit. Überschreite unter 10 000ft nicht 250kts (IAS).",
     "Tipp: Start deine APU bevor du deine Triebwerke abschaltest, damit die Systeme des Flugzeugs weiterlaufen können.",


### PR DESCRIPTION
In the German translation there was a typo. It is called `Treibstoff` and not `Treinbstoff`.